### PR TITLE
Fix for System.ArgumentException in Path.GetDirectoryName(outputPath)…

### DIFF
--- a/SquishIt.Framework/CSS/CSSPathRewriter.cs
+++ b/SquishIt.Framework/CSS/CSSPathRewriter.cs
@@ -65,6 +65,9 @@ namespace SquishIt.Framework.CSS
 
         private static string GetWebPath(string outputPath, IPathTranslator pathTranslator)
         {
+            if (string.IsNullOrEmpty(outputPath))
+                return "/";
+
             return "/" + pathTranslator.ResolveFileSystemPathToAppRelative(Path.GetDirectoryName(outputPath)).TrimStart('/') + "/";
         }
 


### PR DESCRIPTION
… when calling RenderRawContent in CssBundle and outputPath is empty string

For example when css contains relative path for fonts
@font-face {
    src: url('../fonts/OpenSans/OpenSans-Regular.woff2') format('woff2')